### PR TITLE
Refactor code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ reference
 src/commands/future_todo/*
 src/config/*.json
 src/utils/future_todo
+build

--- a/src/commands/animation/flashToPam.ts
+++ b/src/commands/animation/flashToPam.ts
@@ -3,59 +3,50 @@ import { fileUtils, senUtils } from '@/utils';
 import { isXflHasLabel } from '@/utils/project';
 import vscode from 'vscode';
 import * as fs from 'fs';
-import { MissingLibrary } from '@/error';
+import { assert_if, MissingLibrary } from '@/error';
+import { showMessage } from '@/utils/vscode';
+import { spawn_launcher } from '../command_wrapper';
 
-export function execute(context:vscode.ExtensionContext) {
-    return async function (uri:vscode.Uri) {
-        const xflPath = await fileUtils.validatePath(uri, ValidationPathType.folder, ['.xfl'], {
-            fileNotFound: 'XFL not found!',
-            invalidFileType: 'Unsupported file type! Supported file type: .xfl'
-        });
+export function execute(context: vscode.ExtensionContext) {
+	return async function (uri: vscode.Uri) {
+		const xflPath = await fileUtils.validatePath(uri, ValidationPathType.folder, ['.xfl'], {
+			fileNotFound: 'XFL not found!',
+			invalidFileType: 'Unsupported file type! Supported file type: .xfl',
+		});
 
-        if(!xflPath) {
-            return;
-        }
+		if (!xflPath) {
+			return;
+		}
 
-        const isSplitLabelBool = await isXflHasLabel(xflPath);
+		const isSplitLabelBool = await isXflHasLabel(xflPath);
 
-        if(isSplitLabelBool === undefined) {
-            return;
-        }
-        vscode.window.showInformationMessage(
-            isSplitLabelBool ? 
-                "Label folder found! Proceeds to convert with split label"
-                :
-                "Label folder is missing, proceeds to convert without split label"
-        );
+		if (isSplitLabelBool === undefined) {
+			return;
+		}
+		showMessage(
+			isSplitLabelBool
+				? 'Label folder found! Proceeds to convert with split label'
+				: 'Label folder is missing, proceeds to convert without split label',
+			'info',
+		);
 
-        const isSplitLabel = isSplitLabelBool.toString();
-        const destinationPath = xflPath.replace('.xfl', '');
+		const isSplitLabel = isSplitLabelBool.toString();
+		const destinationPath = xflPath.replace('.xfl', '');
 
-        try {
-            await senUtils.runSenAndExecute([
-                '-method',
-                'popcap.animation.from_flash_and_encode',
-                '-source',
-                xflPath,
-                '-destination',
-                destinationPath,
-                '-has_label',
-                isSplitLabel
-            ]);
-        } catch (error) {
-            if(
-                error instanceof Error ||
-                error instanceof MissingLibrary ||
-                error instanceof vscode.CancellationError
-            ) {
-                vscode.window.showErrorMessage(error.message);
-                return;
-            }
-        }
-
-        if(!fs.existsSync(destinationPath)) {
-            vscode.window.showErrorMessage('Failed to convert pam to xfl!');
-            return;
-        }
-    };
+		await spawn_launcher({
+			argument: [
+				'-method',
+				'popcap.animation.from_flash_and_encode',
+				'-source',
+				xflPath,
+				'-destination',
+				destinationPath,
+				'-has_label',
+				isSplitLabel,
+			],
+			success() {
+				assert_if(fs.existsSync(destinationPath), 'Failed to convert xfl to pam!');
+			},
+		});
+	};
 }

--- a/src/commands/animation/jsonToPam.ts
+++ b/src/commands/animation/jsonToPam.ts
@@ -1,45 +1,40 @@
-import { MissingLibrary } from '@/error';
+import { assert_if, MissingLibrary } from '@/error';
 import { ValidationPathType } from '@/types';
 import { fileUtils, senUtils } from '@/utils';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import { spawn_launcher } from '../command_wrapper';
 
-export function execute(context:vscode.ExtensionContext) {
-    return async function (uri:vscode.Uri) {
-        const jsonPamPath = await fileUtils.validatePath(uri, ValidationPathType.file, ['.pam.json'], {
-            fileNotFound: 'JSON PAM not found!',
-            invalidFileType: 'Unsupported file type! Supported file type: .pam.json'
-        });
+export function execute(context: vscode.ExtensionContext) {
+	return async function (uri: vscode.Uri) {
+		const jsonPamPath = await fileUtils.validatePath(
+			uri,
+			ValidationPathType.file,
+			['.pam.json'],
+			{
+				fileNotFound: 'JSON PAM not found!',
+				invalidFileType: 'Unsupported file type! Supported file type: .pam.json',
+			},
+		);
 
-        if(!jsonPamPath) {
-            return;
-        }
+		if (!jsonPamPath) {
+			return;
+		}
 
-        const destinationPath = jsonPamPath.replace('.json', '');
+		const destinationPath = jsonPamPath.replace('.json', '');
 
-        try {
-            await senUtils.runSenAndExecute([
-                '-method',
-                'popcap.animation.encode',
-                '-source',
-                jsonPamPath,
-                '-destination',
-                destinationPath
-            ]);
-        } catch (error) {
-            if(
-                error instanceof Error ||
-                error instanceof MissingLibrary ||
-                error instanceof vscode.CancellationError
-            ) {
-                vscode.window.showErrorMessage(error.message);
-                return;
-            }
-        }
-
-        if(!fs.existsSync(destinationPath)) {
-            vscode.window.showErrorMessage('Failed to convert pam to xfl!');
-            return;
-        }
-    };
+		await spawn_launcher({
+			argument: [
+				'-method',
+				'popcap.animation.encode',
+				'-source',
+				jsonPamPath,
+				'-destination',
+				destinationPath,
+			],
+			success() {
+				assert_if(fs.existsSync(destinationPath), 'Failed to convert json to pam!');
+			},
+		});
+	};
 }

--- a/src/commands/animation/pamToFlash.ts
+++ b/src/commands/animation/pamToFlash.ts
@@ -3,50 +3,40 @@ import { fileUtils, senUtils } from '@/utils';
 import { selectAndGetSplitLabel } from '@/utils/project';
 import vscode from 'vscode';
 import * as fs from 'fs';
-import { MissingLibrary } from '@/error';
+import { assert_if, MissingLibrary } from '@/error';
+import { spawn_launcher } from '../command_wrapper';
 
-export function execute(context:vscode.ExtensionContext) {
-    return async function (uri:vscode.Uri) {
-        const pamPath = await fileUtils.validatePath(uri, ValidationPathType.file, ['.pam'], {
-            fileNotFound: 'PAM not found!',
-            invalidFileType: 'Unsupported file type! Supported file type: .pam'
-        });
+export function execute(context: vscode.ExtensionContext) {
+	return async function (uri: vscode.Uri) {
+		const pamPath = await fileUtils.validatePath(uri, ValidationPathType.file, ['.pam'], {
+			fileNotFound: 'PAM not found!',
+			invalidFileType: 'Unsupported file type! Supported file type: .pam',
+		});
 
-        if(!pamPath) {
-            return;
-        }
+		if (!pamPath) {
+			return;
+		}
 
-        const isSplitLabel = await selectAndGetSplitLabel();
+		const isSplitLabel = await selectAndGetSplitLabel();
 
-        const destinationPath = `${pamPath}.xfl`;
+		const destinationPath = `${pamPath}.xfl`;
 
-        try {
-            await senUtils.runSenAndExecute([
-                '-method',
-                'popcap.animation.decode_and_to_flash',
-                '-source',
-                pamPath,
-                '-destination',
-                destinationPath,
-                '-resolution',
-                AnimationResolution.High,
-                '-has_label',
-                isSplitLabel
-            ]);
-        } catch (error) {
-            if(
-                error instanceof Error ||
-                error instanceof MissingLibrary ||
-                error instanceof vscode.CancellationError
-            ) {
-                vscode.window.showErrorMessage(error.message);
-                return;
-            }
-        }
-
-        if(!fs.existsSync(destinationPath)) {
-            vscode.window.showErrorMessage('Failed to convert pam to xfl!');
-            return;
-        }
-    };
+		await spawn_launcher({
+			argument: [
+				'-method',
+				'popcap.animation.decode_and_to_flash',
+				'-source',
+				pamPath,
+				'-destination',
+				destinationPath,
+				'-resolution',
+				AnimationResolution.High,
+				'-has_label',
+				isSplitLabel,
+			],
+			success() {
+				assert_if(fs.existsSync(destinationPath), 'Failed to convert pam to xfl!');
+			},
+		});
+	};
 }

--- a/src/commands/animation/pamToJson.ts
+++ b/src/commands/animation/pamToJson.ts
@@ -1,45 +1,35 @@
-import { MissingLibrary } from '@/error';
+import { assert_if, MissingLibrary } from '@/error';
 import { ValidationPathType } from '@/types';
 import { fileUtils, senUtils } from '@/utils';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import { spawn_launcher } from '../command_wrapper';
 
-export function execute(context:vscode.ExtensionContext) {
-    return async function (uri:vscode.Uri) {
-        const pamPath = await fileUtils.validatePath(uri, ValidationPathType.file, ['.pam'], {
-            fileNotFound: 'PAM not found!',
-            invalidFileType: 'Unsupported file type! Supported file type: .pam'
-        });
+export function execute(context: vscode.ExtensionContext) {
+	return async function (uri: vscode.Uri) {
+		const pamPath = await fileUtils.validatePath(uri, ValidationPathType.file, ['.pam'], {
+			fileNotFound: 'PAM not found!',
+			invalidFileType: 'Unsupported file type! Supported file type: .pam',
+		});
 
-        if(!pamPath) {
-            return;
-        }
+		if (!pamPath) {
+			return;
+		}
 
-        const destinationPath = `${pamPath}.json`;
+		const destinationPath = `${pamPath}.json`;
 
-        try {
-            await senUtils.runSenAndExecute([
-                '-method',
-                'popcap.animation.decode',
-                '-source',
-                pamPath,
-                '-destination',
-                destinationPath
-            ]);
-        } catch (error) {
-            if(
-                error instanceof Error ||
-                error instanceof MissingLibrary ||
-                error instanceof vscode.CancellationError
-            ) {
-                vscode.window.showErrorMessage(error.message);
-                return;
-            }
-        }
-
-        if(!fs.existsSync(destinationPath)) {
-            vscode.window.showErrorMessage('Failed to convert pam to xfl!');
-            return;
-        }
-    };
+		await spawn_launcher({
+			argument: [
+				'-method',
+				'popcap.animation.decode',
+				'-source',
+				pamPath,
+				'-destination',
+				destinationPath,
+			],
+			success() {
+				assert_if(fs.existsSync(destinationPath), 'Failed to convert pam to json!');
+			},
+		});
+	};
 }

--- a/src/commands/command_wrapper.ts
+++ b/src/commands/command_wrapper.ts
@@ -1,0 +1,30 @@
+import { MissingLibrary } from '@/error';
+import { senUtils } from '@/utils';
+import { showMessage } from '@/utils/vscode';
+import vscode from 'vscode';
+
+export interface Parameter {
+	argument: Array<string>;
+	success?: () => void;
+	exception?: () => void;
+}
+
+export async function spawn_launcher({ argument, success, exception }: Parameter): Promise<void> {
+	try {
+		await senUtils.runSenAndExecute(argument);
+		if (success !== undefined) {
+			success();
+		}
+	} catch (error) {
+		if (
+			error instanceof Error ||
+			error instanceof MissingLibrary ||
+			error instanceof vscode.CancellationError
+		) {
+			showMessage(error.message, 'error');
+		}
+		if (exception !== undefined) {
+			exception();
+		}
+	}
+}

--- a/src/commands/obb/buildProject.ts
+++ b/src/commands/obb/buildProject.ts
@@ -3,74 +3,81 @@ import { fileUtils, senUtils } from '@/utils';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
-import { initializeProjectConfig, selectAndGetTextureCategory, selectObbBundleFolder } from '@/utils/project';
+import {
+	initializeProjectConfig,
+	selectAndGetTextureCategory,
+	selectObbBundleFolder,
+} from '@/utils/project';
+import { spawn_launcher } from '../command_wrapper';
+import { assert_if } from '@/error';
+import { showInfo, showMessage } from '@/utils/vscode';
 
 export function execute(context: vscode.ExtensionContext) {
-    return async (uri:vscode.Uri) => {
-        const allowedExtensions = ['.senproj', '.bundle'];
+	return async (uri: vscode.Uri) => {
+		const allowedExtensions = ['.senproj', '.bundle'];
 
-        const projectPath = uri ?
-            await fileUtils.validatePath(uri, ValidationPathType.folder, allowedExtensions, {
-                fileNotFound: 'Project not found!',
-                invalidFileType: `Unsupported file type! Supported file type: ${allowedExtensions.join(', ')}`
-            })
-            : await fileUtils.validateWorkspacePath(allowedExtensions);
+		const projectPath = uri
+			? await fileUtils.validatePath(uri, ValidationPathType.folder, allowedExtensions, {
+					fileNotFound: 'Project not found!',
+					invalidFileType: `Unsupported file type! Supported file type: ${allowedExtensions.join(
+						', ',
+					)}`,
+			  })
+			: await fileUtils.validateWorkspacePath(allowedExtensions);
 
-        if(!projectPath) {
-            return;
-        }
-        
-        let obbPath:string = projectPath;
-        let textureCategoryOption:textureCategory;
+		if (!projectPath) {
+			return;
+		}
 
-        if(projectPath.endsWith('.senproj')) {
-            const configFileName = "config.json";
-            const configPath = path.join(projectPath, configFileName);
+		let obbPath: string = projectPath;
+		let textureCategoryOption: textureCategory;
 
-            const configData:ProjectConfig = fileUtils.readJson(configPath, false);
+		if (projectPath.endsWith('.senproj')) {
+			const configFileName = 'config.json';
+			const configPath = path.join(projectPath, configFileName);
 
-            if(!configData) {
-                vscode.window.showInformationMessage("Configuration missing. Please choose an option.");
-                const projectObbPath = await selectObbBundleFolder(projectPath);
+			const configData: ProjectConfig = fileUtils.readJson(configPath, false);
 
-                if(!projectObbPath) {
-                    return;
-                }
+			if (!configData) {
+				showInfo('Configuration missing. Please choose an option.');
+				const projectObbPath = await selectObbBundleFolder(projectPath);
 
-                obbPath = projectObbPath;
+				if (!projectObbPath) {
+					return;
+				}
 
-                const obbFile = projectObbPath.split('\\').at(-1)?.replace('.bundle', '');
-                textureCategoryOption = await selectAndGetTextureCategory();
+				obbPath = projectObbPath;
 
-                const projectName = projectPath.split('\\').at(-1)?.replace('.senproj', '');
-                initializeProjectConfig(context, projectName!, projectPath, obbFile!);
-            } else {
-                obbPath = path.join(projectPath, `${configData.obbName}.bundle`);
-                textureCategoryOption = configData.option.textureCategory;
-            }
-        } else {
-            textureCategoryOption = await selectAndGetTextureCategory();
-        }
+				const obbFile = projectObbPath.split('/').at(-1)?.replace('.bundle', '');
+				textureCategoryOption = await selectAndGetTextureCategory();
 
-        const destinationPath = obbPath.replace('.bundle', '');
+				const projectName = projectPath.split('/').at(-1)?.replace('.senproj', '');
+				initializeProjectConfig(context, projectName!, projectPath, obbFile!);
+			} else {
+				obbPath = path.join(projectPath, `${configData.obbName}.bundle`);
+				textureCategoryOption = configData.option.textureCategory;
+			}
+		} else {
+			textureCategoryOption = await selectAndGetTextureCategory();
+		}
 
-        await senUtils.runSenAndExecute([
-            '-method',
-            'popcap.rsb.build_project',
-            '-source',
-            obbPath,
-            '-destination',
-            destinationPath,
-            '-generic',
-            textureCategoryOption
-        ])
-        .catch(err => vscode.window.showErrorMessage(err));
+		const destinationPath = obbPath.replace('.bundle', '');
 
-        if(!fs.existsSync(destinationPath)) {
-            vscode.window.showErrorMessage('Failed to build project!');
-            return;
-        }
-
-        vscode.window.showInformationMessage(`Project built successfully!\nLocated at ${destinationPath}`);
-    };
+		await spawn_launcher({
+			argument: [
+				'-method',
+				'popcap.rsb.build_project',
+				'-source',
+				obbPath,
+				'-destination',
+				destinationPath,
+				'-generic',
+				textureCategoryOption,
+			],
+			success() {
+				assert_if(fs.existsSync(destinationPath), 'Failed to convert pam to xfl!');
+				showMessage(`Project built successfully!\nLocated at ${destinationPath}`, 'info');
+			},
+		});
+	};
 }

--- a/src/commands/obb/initProject.ts
+++ b/src/commands/obb/initProject.ts
@@ -1,107 +1,92 @@
-import { MissingDirectory, MissingLibrary } from '@/error';
+import { assert_if, MissingDirectory, MissingLibrary } from '@/error';
 import { MessageOptions, ValidationPathType } from '@/types';
 import { fileUtils } from '@/utils';
 import { initializeProjectConfig, selectAndGetTextureCategory } from '@/utils/project';
-import { runSenAndExecute } from '@/utils/sen';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
+import { spawn_launcher } from '../command_wrapper';
+import { showBoolean, showError, spawn_command, uriOf } from '@/utils/vscode';
 
 export function execute(context: vscode.ExtensionContext) {
-    return async (uri: vscode.Uri) => {
-        const obbPath = await fileUtils.validatePath(uri, ValidationPathType.file, ['.obb'], {
-            fileNotFound: 'OBB not found!',
-            invalidFileType: 'Unsupported file type! Supported file type: .obb'
-        });
-    
-        if(!obbPath) {
-            return;
-        }
-        
-        const projectName = await vscode.window.showInputBox({
-            prompt: 'Project name',
-            placeHolder: `Input your project name (insert '.' for current directory)`
-        });
-    
-        let projectFullPath = obbPath;
-        let projectPath = obbPath;
+	return async (uri: vscode.Uri) => {
+		const obbPath = await fileUtils.validatePath(uri, ValidationPathType.file, ['.obb'], {
+			fileNotFound: 'OBB not found!',
+			invalidFileType: 'Unsupported file type! Supported file type: .obb',
+		});
 
-        const textureCategoryOption = await selectAndGetTextureCategory();
+		if (!obbPath) {
+			return;
+		}
 
-        const isProjectNameNotEmpty = projectName && projectName !== '.';
+		const projectName = await vscode.window.showInputBox({
+			prompt: 'Project name',
+			placeHolder: `Input your project name (insert '.' for current directory)`,
+		});
 
-        if(isProjectNameNotEmpty) {
-            // Create {ProjectName}.senproj folder for better organization
-            const pathParts = obbPath.split('\\');
-            const obbFile = pathParts.pop();
+		let projectFullPath = obbPath;
+		let projectPath = obbPath;
 
-            if(!obbFile) {
-                vscode.window.showErrorMessage(`Input OBB doesn't exists!`);
-                return;
-            }
-            pathParts.push(`${projectName}.senproj`);
+		const textureCategoryOption = await selectAndGetTextureCategory();
 
-            projectPath = pathParts.join('\\');
-            fs.mkdirSync(projectPath);
+		const isProjectNameNotEmpty = projectName && projectName !== '.';
 
-            initializeProjectConfig(context, projectName, projectPath, obbFile);
+		if (isProjectNameNotEmpty) {
+			// Create {ProjectName}.senproj folder for better organization
+			const pathParts = obbPath.split('/');
+			const obbFile = pathParts.pop();
 
-            pathParts.push(`${obbFile}.bundle`);
+			if (!obbFile) {
+				showError(`Input OBB doesn't exists!`);
+				return;
+			}
+			pathParts.push(`${projectName}.senproj`);
 
-            projectFullPath = pathParts.join('\\');
-        }
+			projectPath = pathParts.join('/');
+			fs.mkdirSync(projectPath);
 
-        try {
-            await runSenAndExecute([
-                '-method',
-                'popcap.rsb.init_project',
-                '-source',
-                obbPath,
-                '-destination',
-                projectFullPath,
-                '-generic',
-                textureCategoryOption
-            ]);
+			initializeProjectConfig(context, projectName, projectPath, obbFile);
 
-            if(!fs.existsSync(projectFullPath)) {
-                throw new MissingDirectory(`Failed to init project: resulting path doesn't exists`);
-            }
-        } catch (error) {
-            if(
-                error instanceof Error ||
-                error instanceof MissingLibrary ||
-                error instanceof MissingDirectory
-            ) {
-                vscode.window.showErrorMessage(error.message);
-            }
+			pathParts.push(`${obbFile}.bundle`);
 
-            if(isProjectNameNotEmpty && !(error instanceof MissingDirectory)) {
-                fs.rm(
-                    projectFullPath, 
-                    {
-                        recursive: true,
-                        force: true
-                    },
-                    () => null
-                );
-            }
-            return;
-        }
+			projectFullPath = pathParts.join('/');
+		}
 
-        await vscode.window.showInformationMessage(
-            'Initialized project successfully! Open the resulting folder?',
-        
-            MessageOptions.Yes.toString(),
-            MessageOptions.No.toString()
-        ).then((val) => {
-            if(val === MessageOptions.Yes.toString()) {
-                vscode.commands.executeCommand(
-                    'vscode.openFolder', 
-                    vscode.Uri.file(projectPath), 
-                    {
-                        forceReuseWindow: true
-                    }
-                );
-            }
-        });
-    };
+		await spawn_launcher({
+			argument: [
+				'-method',
+				'popcap.rsb.init_project',
+				'-source',
+				obbPath,
+				'-destination',
+				projectFullPath,
+				'-generic',
+				textureCategoryOption,
+			],
+			success() {
+				assert_if(
+					fs.existsSync(projectFullPath),
+					`Failed to init project: ${projectFullPath} path doesn't exists`,
+				);
+				showBoolean({
+					message: 'Initialized project successfully! Open the resulting folder?',
+					type: 'info',
+					then(e) {
+						spawn_command('vscode.openFolder', uriOf(projectPath));
+					},
+				});
+			},
+			exception() {
+				if (isProjectNameNotEmpty) {
+					fs.rm(
+						projectFullPath,
+						{
+							recursive: true,
+							force: true,
+						},
+						() => null,
+					);
+				}
+			},
+		});
+	};
 }

--- a/src/commands/scg/decodeSimple.ts
+++ b/src/commands/scg/decodeSimple.ts
@@ -3,39 +3,38 @@ import { senUtils } from '@/utils';
 import { validatePath } from '@/utils/file';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import { spawn_launcher } from '../command_wrapper';
+import { assert_if } from '@/error';
+import { showMessage } from '@/utils/vscode';
 
 export function execute(context: vscode.ExtensionContext) {
-    return async (uri: vscode.Uri) => {
-        const scgPath = await validatePath(uri, ValidationPathType.file, ['.scg'], {
-            fileNotFound: 'SCG not found!',
-            invalidFileType: 'Unsupported file type! Supported file type: .scg'
-        });
+	return async (uri: vscode.Uri) => {
+		const scgPath = await validatePath(uri, ValidationPathType.file, ['.scg'], {
+			fileNotFound: 'SCG not found!',
+			invalidFileType: 'Unsupported file type! Supported file type: .scg',
+		});
 
-        if(!scgPath) {
-            return;
-        }
+		if (!scgPath) {
+			return;
+		}
 
-        const fileDestination = scgPath.replace('.scg', '.package');
+		const fileDestination = scgPath.replace('.scg', '.package');
 
-        await senUtils.runSenAndExecute([
-            '-method',
-            'pvz2.custom.scg.decode',
-            '-source',
-            scgPath,
-            '-destination',
-            fileDestination,
-            '-generic',
-            ScgOptions.Simple
-        ])
-        .catch((error) => {
-            vscode.window.showErrorMessage(error);
-        });
-
-        if(!fs.existsSync(fileDestination)) {
-            vscode.window.showErrorMessage('Failed to decode SCG!');
-            return;
-        }
-
-        vscode.window.showInformationMessage('SCG decoded successfully!');
-    };
+		await spawn_launcher({
+			argument: [
+				'-method',
+				'pvz2.custom.scg.decode',
+				'-source',
+				scgPath,
+				'-destination',
+				fileDestination,
+				'-generic',
+				ScgOptions.Simple,
+			],
+			success() {
+				assert_if(fs.existsSync(fileDestination), 'Failed to decode SCG!');
+				showMessage('SCG decoded successfully!', 'info');
+			},
+		});
+	};
 }

--- a/src/commands/scg/encodeAdvanced.ts
+++ b/src/commands/scg/encodeAdvanced.ts
@@ -1,44 +1,48 @@
-import  * as vscode from 'vscode';
-import { ScgOptions, ValidationPathType } from "@/types";
-import { fileUtils, senUtils } from "@/utils";
+import * as vscode from 'vscode';
+import { ScgOptions, ValidationPathType } from '@/types';
+import { fileUtils, senUtils } from '@/utils';
 import * as fs from 'fs';
+import { spawn_launcher } from '../command_wrapper';
+import { assert_if } from '@/error';
+import { showMessage } from '@/utils/vscode';
 
 export function execute(context: vscode.ExtensionContext) {
-    return async (uri: vscode.Uri) => {
-        const packagePath = await fileUtils.validatePath(uri, ValidationPathType.folder, ['.package'], {
-            fileNotFound: 'Package not found!',
-            invalidFileType: 'Unsupported file type! Supported file type: .package'
-        });
-    
-        if(!packagePath) {
-            return;
-        }
-    
-        const isSplitLabel = fileUtils.isEncodeWithSplitLabel(packagePath).toString();
-        
-        const fileDestination = packagePath.replace('.package', '.scg');
-    
-        await senUtils.runSenAndExecute([
-            '-method',
-            'pvz2.custom.scg.encode',
-            '-source',
-            packagePath,
-            '-destination',
-            fileDestination,
-            '-generic',
-            ScgOptions.Advanced,
-            '-animation_split_label',
-            isSplitLabel
-        ])
-        .catch((error) => {
-            vscode.window.showErrorMessage(error);
-        });
+	return async (uri: vscode.Uri) => {
+		const packagePath = await fileUtils.validatePath(
+			uri,
+			ValidationPathType.folder,
+			['.package'],
+			{
+				fileNotFound: 'Package not found!',
+				invalidFileType: 'Unsupported file type! Supported file type: .package',
+			},
+		);
 
-        if(!fs.existsSync(fileDestination)) {
-            vscode.window.showErrorMessage('Failed to decode SCG!');
-            return;
-        }
-    
-        vscode.window.showInformationMessage('SCG encoded successfully!');
-    };
+		if (!packagePath) {
+			return;
+		}
+
+		const isSplitLabel = fileUtils.isEncodeWithSplitLabel(packagePath).toString();
+
+		const fileDestination = packagePath.replace('.package', '.scg');
+
+		await spawn_launcher({
+			argument: [
+				'-method',
+				'pvz2.custom.scg.encode',
+				'-source',
+				packagePath,
+				'-destination',
+				fileDestination,
+				'-generic',
+				ScgOptions.Advanced,
+				'-animation_split_label',
+				isSplitLabel,
+			],
+			success() {
+				assert_if(fs.existsSync(fileDestination), 'Failed to decode SCG!');
+				showMessage('SCG encoded successfully!', 'info');
+			},
+		});
+	};
 }

--- a/src/commands/scg/encodeSimple.ts
+++ b/src/commands/scg/encodeSimple.ts
@@ -1,40 +1,44 @@
-import  * as vscode from 'vscode';
-import { ScgOptions, ValidationPathType } from "@/types";
-import { fileUtils, senUtils } from "@/utils";
+import * as vscode from 'vscode';
+import { ScgOptions, ValidationPathType } from '@/types';
+import { fileUtils, senUtils } from '@/utils';
 import * as fs from 'fs';
+import { spawn_launcher } from '../command_wrapper';
+import { assert_if } from '@/error';
+import { showMessage } from '@/utils/vscode';
 
 export function execute(context: vscode.ExtensionContext) {
-    return async (uri: vscode.Uri) => {
-        const packagePath = await fileUtils.validatePath(uri, ValidationPathType.folder, ['.package'], {
-            fileNotFound: 'Package not found!',
-            invalidFileType: 'Unsupported file type! Supported file type: .package'
-        });
-    
-        if(!packagePath) {
-            return;
-        }
-        
-        const fileDestination = packagePath.replace('.package', '.scg');
-    
-        await senUtils.runSenAndExecute([
-            '-method',
-            'pvz2.custom.scg.encode',
-            '-source',
-            packagePath,
-            '-destination',
-            fileDestination,
-            '-generic',
-            ScgOptions.Simple
-        ])
-        .catch((error) => {
-            vscode.window.showErrorMessage(error);
-        });
+	return async (uri: vscode.Uri) => {
+		const packagePath = await fileUtils.validatePath(
+			uri,
+			ValidationPathType.folder,
+			['.package'],
+			{
+				fileNotFound: 'Package not found!',
+				invalidFileType: 'Unsupported file type! Supported file type: .package',
+			},
+		);
 
-        if(!fs.existsSync(fileDestination)) {
-            vscode.window.showErrorMessage('Failed to decode SCG!');
-            return;
-        }
-    
-        vscode.window.showInformationMessage('SCG encoded successfully!');
-    };
+		if (!packagePath) {
+			return;
+		}
+
+		const fileDestination = packagePath.replace('.package', '.scg');
+
+		await spawn_launcher({
+			argument: [
+				'-method',
+				'pvz2.custom.scg.encode',
+				'-source',
+				packagePath,
+				'-destination',
+				fileDestination,
+				'-generic',
+				ScgOptions.Simple,
+			],
+			success() {
+				assert_if(fs.existsSync(fileDestination), 'Failed to decode SCG!');
+				showMessage('SCG encoded successfully!', 'info');
+			},
+		});
+	};
 }

--- a/src/commands/sen/openGUI.ts
+++ b/src/commands/sen/openGUI.ts
@@ -1,11 +1,11 @@
 import * as SenUtils from '@/utils/sen';
+import { showError } from '@/utils/vscode';
 import * as vscode from 'vscode';
 
 export function execute(context: vscode.ExtensionContext) {
-    return async () => {
-        await SenUtils.openSenGui()
-            .catch((error) => {
-            vscode.window.showErrorMessage(error);
-        });
-    };
+	return async () => {
+		await SenUtils.openSenGui().catch((error) => {
+			showError(error);
+		});
+	};
 }

--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -1,2 +1,10 @@
 export * from './MissingLibrary';
 export * from './MissingDirectory';
+
+export function assert_if(conditional: boolean, message: string): asserts conditional {
+	if (!conditional) {
+		let error = new Error(message);
+		error.name = 'AssertError';
+		throw error;
+	}
+}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,3 +1,4 @@
+import { showInfo } from '@/utils/vscode';
 import * as assert from 'assert';
 
 // You can import and use all API from the 'vscode' module
@@ -6,7 +7,7 @@ import * as vscode from 'vscode';
 // import * as myExtension from '../../extension';
 
 suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+	showInfo('Start all tests.');
 
 	test('Sample test', () => {
 		assert.strictEqual(-1, [1, 2, 3].indexOf(5));

--- a/src/utils/file/fileValidation.ts
+++ b/src/utils/file/fileValidation.ts
@@ -2,83 +2,92 @@ import { ValidationPathType } from '@/types';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import { senUtils } from '..';
+import { showError } from '../vscode';
 
 export async function validateWorkspacePath(
-    allowedExtensions: string[] = []
+	allowedExtensions: string[] = [],
 ): Promise<string | null> {
-    const workspaceFolders = vscode.workspace.workspaceFolders;
+	const workspaceFolders = vscode.workspace.workspaceFolders;
 
-    if (!workspaceFolders) {
-        vscode.window.showErrorMessage('No workspace path found!');
-        return null;
-    }
+	if (!workspaceFolders) {
+		showError('No workspace path found!');
+		return null;
+	}
 
-    if(!workspaceFolders.length) {
-        vscode.window.showErrorMessage('Workspace cannot be empty!');
-        return null;
-    }
+	if (!workspaceFolders.length) {
+		showError('Workspace cannot be empty!');
+		return null;
+	}
 
-    return await validatePath(workspaceFolders[0].uri, ValidationPathType.folder, allowedExtensions, {
-        fileNotFound: 'No workspace path found!',
-        invalidFileType: `Unsupported file type! Supported file type: ${allowedExtensions.join(', ')}`
-    });
+	return await validatePath(
+		workspaceFolders[0].uri,
+		ValidationPathType.folder,
+		allowedExtensions,
+		{
+			fileNotFound: 'No workspace path found!',
+			invalidFileType: `Unsupported file type! Supported file type: ${allowedExtensions.join(
+				', ',
+			)}`,
+		},
+	);
 }
 
 export async function validatePath(
-    uri: vscode.Uri | undefined,
-    allowedPathType: ValidationPathType,
-    allowedExtensions: string[] = [],
-    errorMessages: { [key: string]: string } = {}
+	uri: vscode.Uri | undefined,
+	allowedPathType: ValidationPathType,
+	allowedExtensions: string[] = [],
+	errorMessages: { [key: string]: string } = {},
 ): Promise<string | null> {
-    if(!(await senUtils.validateSenPath())) {
-        return null;
-    }
+	if (!(await senUtils.validateSenPath())) {
+		return null;
+	}
 
-    if (!uri) {
-        vscode.window.showErrorMessage(errorMessages.noFileSelected || 'No file selected!');
-        return null;
-    }
+	if (!uri) {
+		showError(errorMessages.noFileSelected || 'No file selected!');
+		return null;
+	}
 
-    const filePath = uri.fsPath;
+	const filePath = uri.fsPath;
 
-    if (!fs.existsSync(filePath)) {
-        vscode.window.showErrorMessage(errorMessages.fileNotFound || 'File not found!');
-        return null;
-    }
+	if (!fs.existsSync(filePath)) {
+		showError(errorMessages.fileNotFound || `File ${filePath} not found!`);
+		return null;
+	}
 
-    const pathType = await checkPathType(filePath);
+	const pathType = await checkPathType(filePath);
 
-    if (!pathType || pathType !== allowedPathType) {
-        vscode.window.showErrorMessage(
-            errorMessages.invalidPathType ||
-            `Invalid pathParam type! Given: ${pathType}, Required: ${allowedPathType}`
-        );
-        return null;
-    }
+	if (!pathType || pathType !== allowedPathType) {
+		showError(
+			errorMessages.invalidPathType ||
+				`Invalid pathParam type! Given: ${pathType}, Required: ${allowedPathType}`,
+		);
+		return null;
+	}
 
-    if (allowedExtensions.length > 0 && !allowedExtensions.some(ext => filePath.endsWith(ext))) {
-        vscode.window.showErrorMessage(
-            errorMessages.invalidFileType || `Unsupported file type! Supported types: ${allowedExtensions.join(', ')}`
-        );
-        return null;
-    }
+	if (allowedExtensions.length > 0 && !allowedExtensions.some((ext) => filePath.endsWith(ext))) {
+		showError(
+			errorMessages.invalidFileType ||
+				`Unsupported file type! Supported types: ${allowedExtensions.join(', ')}`,
+		);
+		return null;
+	}
 
-    return filePath;
+	return filePath.replaceAll('\\', '/');
 }
 
-export async function checkPathType(pathParam: string): Promise<string|null> {
-    try {
-        const stats = await fs.promises.stat(pathParam);
+export async function checkPathType(pathParam: string): Promise<string | null> {
+	try {
+		const stats = await fs.promises.stat(pathParam);
 
-        if(stats.isDirectory()) {
-            return ValidationPathType.folder;
-        } else if(stats.isFile()) {
-            return ValidationPathType.file;
-        } else {
-            return ValidationPathType.unknown;
-        }
-    } catch (error) {
-        vscode.window.showErrorMessage(`Failed to check pathParam type: ${error}`);
-        return null;
-    }
+		if (stats.isDirectory()) {
+			return ValidationPathType.folder;
+		} else if (stats.isFile()) {
+			return ValidationPathType.file;
+		} else {
+			return ValidationPathType.unknown;
+		}
+	} catch (error) {
+		showError(`Failed to check pathParam type: ${error}`);
+		return null;
+	}
 }

--- a/src/utils/file/jsonUtils.ts
+++ b/src/utils/file/jsonUtils.ts
@@ -2,77 +2,81 @@ import { DataJson, ProjectConfig, textureCategory } from '@/types';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { showError } from '../vscode';
 
-function readDataJson(pathParam: string, reviver?: (key:string, value:any) => any): DataJson | null {
-    try {
-        const dataJsonPath = path.join(pathParam, 'data.json');
-        const data = fs.readFileSync(dataJsonPath, 'utf-8');
-        return JSON.parse(data, reviver);
-    } catch (error) {
-        vscode.window.showErrorMessage(`Failed to read data.json: ${error}`);
-        return null;
-    }
+function readDataJson(
+	pathParam: string,
+	reviver?: (key: string, value: any) => any,
+): DataJson | null {
+	try {
+		const dataJsonPath = path.join(pathParam, 'data.json');
+		const data = fs.readFileSync(dataJsonPath, 'utf-8');
+		return JSON.parse(data, reviver);
+	} catch (error) {
+		showError(`Failed to read data.json: ${error}`);
+		return null;
+	}
 }
 
 export function writeSplitLabelIntoJson(pathParam: string, isSplitLabel: boolean): void {
-    const dataJson:DataJson|null = readDataJson(pathParam);
+	const dataJson: DataJson | null = readDataJson(pathParam);
 
-    if(!dataJson) {
-        vscode.window.showErrorMessage(`Failed to write ${pathParam}\\data.json: Missing data.json!`);
-        return;
-    }
+	if (!dataJson) {
+		showError(`Failed to write ${pathParam}\\data.json: Missing data.json!`);
+		return;
+	}
 
-    const splitLabel = {
-        '#split_label': isSplitLabel ?? isEncodeWithSplitLabel(pathParam)
-    };
+	const splitLabel = {
+		'#split_label': isSplitLabel ?? isEncodeWithSplitLabel(pathParam),
+	};
 
-    const dataJsonStr = JSON.stringify({...splitLabel, ...dataJson}, null, 4);
+	const dataJsonStr = JSON.stringify({ ...splitLabel, ...dataJson }, null, 4);
 
-    try {
-        const dataJsonPath = path.join(pathParam, 'data.json');
-        fs.createWriteStream(dataJsonPath, { flags: 'w' }).write(dataJsonStr);
-    } catch (error) {
-        vscode.window.showErrorMessage(`Failed to write ${pathParam}\\data.json: ${error}`);
-    }
+	try {
+		const dataJsonPath = path.join(pathParam, 'data.json');
+		fs.createWriteStream(dataJsonPath, { flags: 'w' }).write(dataJsonStr);
+	} catch (error) {
+		showError(`Failed to write ${pathParam}\\data.json: ${error}`);
+	}
 }
 
-export function isEncodeWithSplitLabel(pathParam:string): boolean {
-    const dataJson:DataJson|null = readDataJson(pathParam);
+export function isEncodeWithSplitLabel(pathParam: string): boolean {
+	const dataJson: DataJson | null = readDataJson(pathParam);
 
-    if(!dataJson || !dataJson['#split_label']) {
-        return true;
-    }
+	if (!dataJson || !dataJson['#split_label']) {
+		return true;
+	}
 
-    return dataJson['#split_label'];
+	return dataJson['#split_label'];
 }
 
 export function writeJson(pathParam: string, data: any) {
-    try {
-        fs.writeFileSync(pathParam, JSON.stringify(data, null, 4));
-    } catch (error) {
-        vscode.window.showErrorMessage(`Failed to write ${pathParam}: ${error}`);
-    }
+	try {
+		fs.writeFileSync(pathParam, JSON.stringify(data, null, 4));
+	} catch (error) {
+		showError(`Failed to write ${pathParam}: ${error}`);
+	}
 }
 
 export function readJsonFromConfig(context: vscode.ExtensionContext, configName: string) {
-    try {
-        const dataPath = path.join(context.extensionPath, 'src', 'config', configName);
-        const data = fs.readFileSync(dataPath, 'utf-8');
-        return JSON.parse(data);
-    } catch (error) {
-        vscode.window.showErrorMessage(`Failed to read ${configName}: ${error}`);
-        return null;
-    }
+	try {
+		const dataPath = path.join(context.extensionPath, 'src', 'config', configName);
+		const data = fs.readFileSync(dataPath, 'utf-8');
+		return JSON.parse(data);
+	} catch (error) {
+		showError(`Failed to read ${configName}: ${error}`);
+		return null;
+	}
 }
 
 export function readJson(path: string, showErrorMessage: boolean = true) {
-    try {
-        const data = fs.readFileSync(path, 'utf-8');
-        return JSON.parse(data);
-    } catch (error) {
-        if(showErrorMessage) {
-            vscode.window.showErrorMessage(`Failed to read ${path}: ${error}`);
-        }
-        return null;
-    }
+	try {
+		const data = fs.readFileSync(path, 'utf-8');
+		return JSON.parse(data);
+	} catch (error) {
+		if (showErrorMessage) {
+			showError(`Failed to read ${path}: ${error}`);
+		}
+		return null;
+	}
 }

--- a/src/utils/project/projectAnims.ts
+++ b/src/utils/project/projectAnims.ts
@@ -1,37 +1,38 @@
-import { MessageOptions } from "@/types";
-import path from "path";
+import { MessageOptions } from '@/types';
+import path from 'path';
 import fs from 'fs';
 import * as vscode from 'vscode';
+import { showError } from '../vscode';
 
 export async function selectAndGetSplitLabel() {
-    return await vscode.window.showQuickPick([
-        MessageOptions.Yes,
-        MessageOptions.No
-    ], {
-        title: 'Split animation label?',
-        placeHolder: 'Split animation label? (Default: Yes)'
-    })
-    .then((val) => !val ? MessageOptions.Yes : val)
-    .then((val) => (val && val === MessageOptions.Yes).toString());
+	return await vscode.window
+		.showQuickPick([MessageOptions.Yes, MessageOptions.No], {
+			title: 'Split animation label?',
+			placeHolder: 'Split animation label? (Default: Yes)',
+		})
+		.then((val) => (!val ? MessageOptions.Yes : val))
+		.then((val) => (val && val === MessageOptions.Yes).toString());
 }
 
-export async function isXflHasLabel(xflPath:string) {
-    const libraryPath = path.join(xflPath, 'library');
-    const labelFolderName = "label";
+export async function isXflHasLabel(xflPath: string) {
+	const libraryPath = path.join(xflPath, 'library');
+	const labelFolderName = 'label';
 
-    try {
-        const entries = await fs.promises.readdir(libraryPath, { withFileTypes: true });
+	try {
+		const entries = await fs.promises.readdir(libraryPath, { withFileTypes: true });
 
-        const folderEntry = entries.find(entry => entry.isDirectory() && entry.name === labelFolderName);
+		const folderEntry = entries.find(
+			(entry) => entry.isDirectory() && entry.name === labelFolderName,
+		);
 
-        if(folderEntry) {
-            return true;
-        }
-        return false;
-    } catch (error) {
-        if(error instanceof Error) {
-            vscode.window.showErrorMessage(`Error reading xfl: ${error.message}`);
-        }
-        return;
-    }
+		if (folderEntry) {
+			return true;
+		}
+		return false;
+	} catch (error) {
+		if (error instanceof Error) {
+			showError(`Error reading xfl: ${error.message}`);
+		}
+		return;
+	}
 }

--- a/src/utils/sen/senLauncher.ts
+++ b/src/utils/sen/senLauncher.ts
@@ -2,116 +2,119 @@ import * as vscode from 'vscode';
 import { getLauncherLibraries, getLauncherPath, getSenGuiPath } from './senPaths';
 import { spawn } from 'node:child_process';
 import { MissingLibrary } from '@/error';
+import { showError, showInfo } from '../vscode';
 
 export async function runSenAndExecute(args: string[]): Promise<void> {
-    return vscode.window.withProgress({
-            location: vscode.ProgressLocation.Notification,
-            title: 'Running command...',
-            cancellable: true
-        },
-        async (progress, token) => {
-            return new Promise((resolve, reject) => {
-                const launcherPath = getLauncherPath();
-        
-                if (!launcherPath) {
-                    reject(new MissingLibrary('Launcher path is not valid'));
-                }
-                
-                const launcherLibraries: string[] | 'none' | null = getLauncherLibraries();
-                
-                if(!launcherLibraries) {
-                    reject(new MissingLibrary('Launcher libraries are not valid!'));
-                }
+	return vscode.window.withProgress(
+		{
+			location: vscode.ProgressLocation.Notification,
+			title: 'Running command...',
+			cancellable: true,
+		},
+		async (progress, token) => {
+			return new Promise((resolve, reject) => {
+				const launcherPath = getLauncherPath();
 
-                const libraryArgument = Array.isArray(launcherLibraries) ? [...launcherLibraries] : [];
+				if (!launcherPath) {
+					reject(new MissingLibrary('Launcher path is not valid'));
+				}
 
-                const childArgs = [
-                    ...libraryArgument,
-                    ...args
-                ];
+				const launcherLibraries: string[] | 'none' | null = getLauncherLibraries();
 
-                const child = spawn(launcherPath!, childArgs);
-                let hasError = false;
-                let errorMessage:string;
-                let errorStackTrace:string;
+				if (!launcherLibraries) {
+					reject(new MissingLibrary('Launcher libraries are not valid!'));
+				}
 
-                child.stdout.on('data', (data) => {
-                    console.log(`Output: ${data.toString()}`);
+				const libraryArgument = Array.isArray(launcherLibraries)
+					? [...launcherLibraries]
+					: [];
 
-                    const messages:string[] = data.toString().split('●').map((msg:string) => msg.trim()).filter((msg:string) => msg);
-                    
-                    messages.forEach(message => {
-                        if (message.includes("Error")) {
-                            errorMessage = message;
-                            hasError = true;
-                        }
-                        if(/^Stack for traceback error/i.test(message)) {
-                            errorStackTrace = message;
-                            hasError = true;
-                        }
-                    });
-                    
-                });
+				const childArgs = [...libraryArgument, ...args];
 
-                child.stderr.on('data', (data) => {
-                    console.error(`Error Output: ${data.toString()}`);
-                });
+				const child = spawn(launcherPath!, childArgs);
+				let hasError = false;
+				let errorMessage: string;
+				let errorStackTrace: string;
 
-                child.on('close', (code) => {
-                    if(code === 0 && !hasError) {
-                        vscode.window.showInformationMessage('Command completed successfully');
-                        resolve();
-                    } else if(hasError) {
-                        vscode.window.showErrorMessage(errorMessage);
-                        vscode.window.showErrorMessage('Command reported success but errors were found!');
-                        reject(new Error(errorStackTrace));
-                    }
-                    else {
-                        vscode.window.showErrorMessage(`Command failed with code ${code}`);
-                        reject(new Error(`Command exited with code ${code}`));
-                    }
-                });
+				child.stdout.on('data', (data) => {
+					console.log(`Output: ${data.toString()}`);
 
-                child.on('error', (err) => {
-                    vscode.window.showErrorMessage(`Failed to run command: ${err.message}`);
-                    reject(err);
-                });
+					const messages: string[] = data
+						.toString()
+						.split('●')
+						.map((msg: string) => msg.trim())
+						.filter((msg: string) => msg);
 
-                token.onCancellationRequested(() => {
-                    vscode.window.showInformationMessage('Cancelling process...');
-                    child.kill('SIGTERM');
-                    reject(new vscode.CancellationError());
-                });
-            });
-        }
-    );
+					messages.forEach((message) => {
+						if (message.includes('Error')) {
+							errorMessage = message;
+							hasError = true;
+						}
+						if (/^Stack for traceback error/i.test(message)) {
+							errorStackTrace = message;
+							hasError = true;
+						}
+					});
+				});
+
+				child.stderr.on('data', (data) => {
+					console.error(`Error Output: ${data.toString()}`);
+				});
+
+				child.on('close', (code) => {
+					if (code === 0 && !hasError) {
+						showInfo('Command completed successfully');
+						resolve();
+					} else if (hasError) {
+						showError(errorMessage);
+						showError('Command reported success but errors were found!');
+						reject(new Error(errorStackTrace));
+					} else {
+						showError(`Command failed with code ${code}`);
+						reject(new Error(`Command exited with code ${code}`));
+					}
+				});
+
+				child.on('error', (err) => {
+					showError(`Failed to run command: ${err.message}`);
+					reject(err);
+				});
+
+				token.onCancellationRequested(() => {
+					showInfo('Cancelling process...');
+					child.kill('SIGTERM');
+					reject(new vscode.CancellationError());
+				});
+			});
+		},
+	);
 }
 
 export async function openSenGui(): Promise<void> {
-    return new Promise(async (resolve) => {
-        const terminals = vscode.window.terminals;
-        let terminal = vscode.window.createTerminal();
+	return new Promise(async (resolve) => {
+		const terminals = vscode.window.terminals;
+		let terminal = vscode.window.createTerminal();
 
-        if (terminals.length > 0) {
-            terminal = terminals[0];
-        }
+		if (terminals.length > 0) {
+			terminal = terminals[0];
+		}
 
-        const senGuiPath = getSenGuiPath();
+		const senGuiPath = getSenGuiPath();
 
-        if (!senGuiPath) {
-            vscode.window.showErrorMessage('Sen GUI not found!');
-            resolve();
-            return;
-        }
+		if (!senGuiPath) {
+			showError('Sen GUI not found!');
+			resolve();
+			return;
+		}
 
-        terminal.sendText(senGuiPath, true);
+		terminal.sendText(senGuiPath, true);
 
-        const interval = setInterval(() => {
-            if (terminal.exitStatus) {
-                terminal.dispose();
-                clearInterval(interval);
-                resolve();
-            }
-        }, 1000);
-    });
+		const interval = setInterval(() => {
+			if (terminal.exitStatus) {
+				terminal.dispose();
+				clearInterval(interval);
+				resolve();
+			}
+		}, 1000);
+	});
 }

--- a/src/utils/sen/senPaths.ts
+++ b/src/utils/sen/senPaths.ts
@@ -4,72 +4,82 @@ import { replaceWithConfig } from '../configUtils';
 import { isSenPathExists } from './senValidation';
 import { SenLauncherType } from '@/types';
 import * as fs from 'fs';
+import { showMessage } from '../vscode';
 
 export function getSenPath(): string | undefined {
-    return vscode.workspace.getConfiguration('sen-helper').get('path.sen');
+	return vscode.workspace.getConfiguration('sen-helper').get('path.sen');
 }
 
 export function getSenGuiPath(): string | undefined {
-    const senPath = getSenPath();
+	const senPath = getSenPath();
 
-    if (!isSenPathExists() || !senPath) { 
-        return undefined; 
-    }
+	if (!isSenPathExists() || !senPath) {
+		return undefined;
+	}
 
-    const config: string | undefined = vscode.workspace.getConfiguration('sen-helper').get('path.sui');
+	const config: string | undefined = vscode.workspace
+		.getConfiguration('sen-helper')
+		.get('path.sui');
 
-    if (!config) {
-        return undefined;
-    }
+	if (!config) {
+		return undefined;
+	}
 
-    return replaceWithConfig(config);
+	return replaceWithConfig(config);
 }
 
 export function getLauncherPath(): string | null {
-    const senPath = getSenPath();
+	const senPath = getSenPath();
 
-    if (!isSenPathExists() || !senPath) {
-        return null;
-    }
+	if (!isSenPathExists() || !senPath) {
+		return null;
+	}
 
-    const config: string | undefined = vscode.workspace.getConfiguration('sen-helper').get('advanced.launcher');
-    if (!config) {
-        return null;
-    }
+	const config: string | undefined = vscode.workspace
+		.getConfiguration('sen-helper')
+		.get('advanced.launcher');
+	if (!config) {
+		return null;
+	}
 
-    const launcherExecutable = `${config}.exe`;
-    return path.join(senPath, launcherExecutable);
+	const launcherExecutable = `${config}.exe`;
+	return path.join(senPath, launcherExecutable);
 }
 
-export function getLauncherLibraries(): string[] | 'none' | null  {
-    const senPath = getSenPath();
+export function getLauncherLibraries(): string[] | 'none' | null {
+	const senPath = getSenPath();
 
-    if (!isSenPathExists() || !senPath) {
-        return null;
-    }
+	if (!isSenPathExists() || !senPath) {
+		return null;
+	}
 
-    const config: string | undefined = vscode.workspace.getConfiguration('sen-helper').get('advanced.launcher');
-    if (!config) {
-        return null;
-    }
+	const config: string | undefined = vscode.workspace
+		.getConfiguration('sen-helper')
+		.get('advanced.launcher');
+	if (!config) {
+		return null;
+	}
 
-    if(config === SenLauncherType.Launcher) {
-        return 'none';
-    }
+	if (config === SenLauncherType.Launcher) {
+		return 'none';
+	}
 
-    const kernelPath = path.join(senPath, 'Kernel.dll');
-    const scriptPath = path.join(senPath, 'script');
-    const mainScriptPath = path.join(scriptPath, 'main.js');
+	const kernelPath = path.join(senPath, 'Kernel.dll');
+	const scriptPath = path.join(senPath, 'script');
+	const mainScriptPath = path.join(scriptPath, 'main.js');
 
-    if(!fs.existsSync(kernelPath) && config === SenLauncherType.Shell) {
-        vscode.window.showErrorMessage(`Missing Kernel.dll at ${senPath}`);
-        return null;
-    }
+	if (!fs.existsSync(kernelPath) && config === SenLauncherType.Shell) {
+		showMessage(`Missing Kernel.dll at ${senPath}`, 'error');
+		return null;
+	}
 
-    if((!fs.existsSync(scriptPath) || !fs.existsSync(mainScriptPath)) && config === SenLauncherType.Shell) {
-        vscode.window.showErrorMessage(`Missing script folder or main.js at ${senPath}`);
-        return null;
-    }
+	if (
+		(!fs.existsSync(scriptPath) || !fs.existsSync(mainScriptPath)) &&
+		config === SenLauncherType.Shell
+	) {
+		showMessage(`Missing script folder or main.js at ${senPath}`, 'error');
+		return null;
+	}
 
-    return [kernelPath, mainScriptPath];
+	return [kernelPath, mainScriptPath];
 }

--- a/src/utils/sen/senValidation.ts
+++ b/src/utils/sen/senValidation.ts
@@ -1,48 +1,49 @@
 import * as vscode from 'vscode';
-import { MessageOptions } from "@/types";
+import { MessageOptions } from '@/types';
 import { getSenPath, getLauncherPath } from '.';
 import * as fs from 'fs';
+import { showMessage } from '../vscode';
 
 export async function validateSenPath(): Promise<boolean> {
-    if (!isSenPathExists()) {
-        const options = [MessageOptions.OpenSettings, MessageOptions.Cancel];
+	if (!isSenPathExists()) {
+		const options = [MessageOptions.OpenSettings, MessageOptions.Cancel];
 
-        const answer = await vscode.window.showErrorMessage(
-            'Sen path is not set, open settings?',
-            ...options
-        );
+		const answer = await vscode.window.showErrorMessage(
+			'Sen path is not set, open settings?',
+			...options,
+		);
 
-        if (answer === MessageOptions.OpenSettings) {
-            vscode.commands.executeCommand('workbench.action.openSettings', 'sen-helper.path');
-        }
-        return false;
-    }
+		if (answer === MessageOptions.OpenSettings) {
+			vscode.commands.executeCommand('workbench.action.openSettings', 'sen-helper.path');
+		}
+		return false;
+	}
 
-    if (!isSenLauncherExists()) {
-        vscode.window.showErrorMessage('Sen launcher not found!');
-        return false;
-    }
+	if (!isSenLauncherExists()) {
+		showMessage('Sen launcher not found!', 'error');
+		return false;
+	}
 
-    return true;
+	return true;
 }
 
 export function isSenPathExists(): boolean {
-    const senPath = getSenPath();
-    return senPath !== undefined && senPath !== '' && senPath !== null;
+	const senPath = getSenPath();
+	return senPath !== undefined && senPath !== '' && senPath !== null;
 }
 
 export function isSenLauncherExists(): boolean {
-    const launcherPath = getLauncherPath();
+	const launcherPath = getLauncherPath();
 
-    if (!launcherPath) {
-        vscode.window.showErrorMessage('Sen launcher not found!');
-        return false;
-    }
+	if (!launcherPath) {
+		showMessage('Sen launcher not found!', 'error');
+		return false;
+	}
 
-    if (!fs.existsSync(launcherPath)) {
-        vscode.window.showErrorMessage('Sen launcher not found!');
-        return false;
-    }
+	if (!fs.existsSync(launcherPath)) {
+		showMessage('Sen launcher not found!', 'error');
+		return false;
+	}
 
-    return true;
+	return true;
 }

--- a/src/utils/vscode/index.ts
+++ b/src/utils/vscode/index.ts
@@ -1,0 +1,81 @@
+import { MessageOptions } from '@/types';
+import vscode from 'vscode';
+
+export type Type = 'info' | 'error' | 'warning';
+
+export interface Parameter {
+	message: string;
+	type: Type;
+}
+
+export function showMessage(message: string, type: Type): void {
+	switch (type) {
+		case 'info':
+			vscode.window.showInformationMessage(message);
+			break;
+		case 'error':
+			vscode.window.showErrorMessage(message);
+			break;
+		case 'warning':
+			vscode.window.showWarningMessage(message);
+			break;
+	}
+}
+
+export function showError(message: string): void {
+	return showMessage(message, 'error');
+}
+
+export function showInfo(message: string): void {
+	return showMessage(message, 'info');
+}
+
+export function showWarning(message: string): void {
+	return showMessage(message, 'warning');
+}
+
+export interface Parameter {
+	message: string;
+	type: Type;
+	then: (e: string | undefined) => any;
+}
+
+export interface EnumerationParameter extends Parameter {
+	items: Array<string>;
+}
+
+export function showEnumeration({ message, type, items, then }: EnumerationParameter): void {
+	switch (type) {
+		case 'info':
+			vscode.window.showInformationMessage(message, ...items).then(then);
+			break;
+		case 'error':
+			vscode.window.showErrorMessage(message, ...items).then(then);
+			break;
+		case 'warning':
+			vscode.window.showWarningMessage(message, ...items).then(then);
+			break;
+	}
+}
+
+export function showBoolean(it: Parameter): void {
+	return showEnumeration({
+		...it,
+		then: (e) => {
+			if (e === MessageOptions.Yes) {
+				it.then(e);
+			}
+		},
+		items: [MessageOptions.Yes, MessageOptions.No],
+	});
+}
+
+export function spawn_command(command: string, ...rest: Array<any>): void {
+	vscode.commands.executeCommand(command, ...rest, {
+		forceReuseWindow: true,
+	});
+}
+
+export function uriOf(source: string): vscode.Uri {
+	return vscode.Uri.file(source);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,15 +2,14 @@
 	"compilerOptions": {
 		"module": "Node16",
 		"target": "ES2022",
-		"lib": [
-			"ES2022"
-		],
+		"lib": ["ES2022"],
 		"paths": {
 			"@/*": ["./src/*"]
 		},
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": true,   /* enable all strict type-checking options */
+		"strict": true,
+		"outDir": "./build"
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */


### PR DESCRIPTION
This PR refactor the duplicate code, for example:
```ts
try {
    await senUtils.runSenAndExecute([
        '-method',
        'popcap.animation.decode',
        '-source',
        pamPath,
        '-destination',
        destinationPath
    ]);
} catch (error) {
    if(
        error instanceof Error ||
        error instanceof MissingLibrary ||
        error instanceof vscode.CancellationError
    ) {
        vscode.window.showErrorMessage(error.message);
        return;
    }
}
```

to 
```ts
await spawn_launcher({
	argument: [
		'-method',
		'popcap.animation.decode_and_to_flash',
		'-source',
		pamPath,
		'-destination',
		destinationPath,
		'-resolution',
		AnimationResolution.High,
		'-has_label',
		isSplitLabel,
	],
	success() {
		assert_if(fs.existsSync(destinationPath), 'Failed to convert pam to xfl!');
	},
});
```

These codes are simpler to read and more maintainable. Added an Adapter to vscode extension.
