### PR TITLE
Refactor argument

### DIFF
--- a/src/commands/animation/flashToPam.ts
+++ b/src/commands/animation/flashToPam.ts
@@ -1,15 +1,15 @@
 import { ValidationPathType } from '@/types';
-import { fileUtils, senUtils } from '@/utils';
+import { fileUtils } from '@/utils';
 import { isXflHasLabel } from '@/utils/project';
 import vscode from 'vscode';
 import * as fs from 'fs';
-import { assert_if, MissingLibrary } from '@/error';
+import { assert_if } from '@/error';
 import { showMessage } from '@/utils/vscode';
 import { spawn_launcher } from '../command_wrapper';
 
-export function execute(context: vscode.ExtensionContext) {
+export function execute() {
 	return async function (uri: vscode.Uri) {
-		const xflPath = await fileUtils.validatePath(uri, ValidationPathType.folder, ['.xfl'], {
+		const xflPath = await fileUtils.validatePath(uri, ValidationPathType.folder, /(\.xfl)$/i, {
 			fileNotFound: 'XFL not found!',
 			invalidFileType: 'Unsupported file type! Supported file type: .xfl',
 		});
@@ -34,16 +34,12 @@ export function execute(context: vscode.ExtensionContext) {
 		const destinationPath = xflPath.replace('.xfl', '');
 
 		await spawn_launcher({
-			argument: [
-				'-method',
-				'popcap.animation.from_flash_and_encode',
-				'-source',
-				xflPath,
-				'-destination',
-				destinationPath,
-				'-has_label',
-				isSplitLabel,
-			],
+			argument: {
+				method: 'popcap.animation.from_flash_and_encode',
+				source: xflPath,
+				destination: destinationPath,
+				has_label: isSplitLabel,
+			},
 			success() {
 				assert_if(fs.existsSync(destinationPath), 'Failed to convert xfl to pam!');
 			},

--- a/src/commands/animation/jsonToPam.ts
+++ b/src/commands/animation/jsonToPam.ts
@@ -1,16 +1,16 @@
-import { assert_if, MissingLibrary } from '@/error';
+import { assert_if } from '@/error';
 import { ValidationPathType } from '@/types';
-import { fileUtils, senUtils } from '@/utils';
+import { fileUtils } from '@/utils';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import { spawn_launcher } from '../command_wrapper';
 
-export function execute(context: vscode.ExtensionContext) {
+export function execute() {
 	return async function (uri: vscode.Uri) {
 		const jsonPamPath = await fileUtils.validatePath(
 			uri,
 			ValidationPathType.file,
-			['.pam.json'],
+			/(\.pam\.json)$/i,
 			{
 				fileNotFound: 'JSON PAM not found!',
 				invalidFileType: 'Unsupported file type! Supported file type: .pam.json',
@@ -24,14 +24,11 @@ export function execute(context: vscode.ExtensionContext) {
 		const destinationPath = jsonPamPath.replace('.json', '');
 
 		await spawn_launcher({
-			argument: [
-				'-method',
-				'popcap.animation.encode',
-				'-source',
-				jsonPamPath,
-				'-destination',
-				destinationPath,
-			],
+			argument: {
+				method: 'popcap.animation.encode',
+				source: jsonPamPath,
+				destination: destinationPath,
+			},
 			success() {
 				assert_if(fs.existsSync(destinationPath), 'Failed to convert json to pam!');
 			},

--- a/src/commands/animation/pamToFlash.ts
+++ b/src/commands/animation/pamToFlash.ts
@@ -1,19 +1,19 @@
 import { AnimationResolution, ValidationPathType } from '@/types';
-import { fileUtils, senUtils } from '@/utils';
+import { fileUtils } from '@/utils';
 import { selectAndGetSplitLabel } from '@/utils/project';
 import vscode from 'vscode';
 import * as fs from 'fs';
-import { assert_if, MissingLibrary } from '@/error';
+import { assert_if } from '@/error';
 import { spawn_launcher } from '../command_wrapper';
 
-export function execute(context: vscode.ExtensionContext) {
+export function execute() {
 	return async function (uri: vscode.Uri) {
-		const pamPath = await fileUtils.validatePath(uri, ValidationPathType.file, ['.pam'], {
+		const pamPath = await fileUtils.validatePath(uri, ValidationPathType.file, /(\.pam)$/i, {
 			fileNotFound: 'PAM not found!',
 			invalidFileType: 'Unsupported file type! Supported file type: .pam',
 		});
 
-		if (!pamPath) {
+		if (pamPath === undefined) {
 			return;
 		}
 
@@ -22,18 +22,13 @@ export function execute(context: vscode.ExtensionContext) {
 		const destinationPath = `${pamPath}.xfl`;
 
 		await spawn_launcher({
-			argument: [
-				'-method',
-				'popcap.animation.decode_and_to_flash',
-				'-source',
-				pamPath,
-				'-destination',
-				destinationPath,
-				'-resolution',
-				AnimationResolution.High,
-				'-has_label',
-				isSplitLabel,
-			],
+			argument: {
+				method: 'popcap.animation.decode_and_to_flash',
+				source: pamPath,
+				destination: destinationPath,
+				resolution: AnimationResolution.High,
+				has_label: isSplitLabel,
+			},
 			success() {
 				assert_if(fs.existsSync(destinationPath), 'Failed to convert pam to xfl!');
 			},

--- a/src/commands/animation/pamToJson.ts
+++ b/src/commands/animation/pamToJson.ts
@@ -1,13 +1,13 @@
-import { assert_if, MissingLibrary } from '@/error';
+import { assert_if } from '@/error';
 import { ValidationPathType } from '@/types';
-import { fileUtils, senUtils } from '@/utils';
+import { fileUtils } from '@/utils';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import { spawn_launcher } from '../command_wrapper';
 
-export function execute(context: vscode.ExtensionContext) {
+export function execute() {
 	return async function (uri: vscode.Uri) {
-		const pamPath = await fileUtils.validatePath(uri, ValidationPathType.file, ['.pam'], {
+		const pamPath = await fileUtils.validatePath(uri, ValidationPathType.file, /(\.pam)$/i, {
 			fileNotFound: 'PAM not found!',
 			invalidFileType: 'Unsupported file type! Supported file type: .pam',
 		});
@@ -19,14 +19,11 @@ export function execute(context: vscode.ExtensionContext) {
 		const destinationPath = `${pamPath}.json`;
 
 		await spawn_launcher({
-			argument: [
-				'-method',
-				'popcap.animation.decode',
-				'-source',
-				pamPath,
-				'-destination',
-				destinationPath,
-			],
+			argument: {
+				method: 'popcap.animation.decode',
+				source: pamPath,
+				destination: destinationPath,
+			},
 			success() {
 				assert_if(fs.existsSync(destinationPath), 'Failed to convert pam to json!');
 			},

--- a/src/commands/command_wrapper.ts
+++ b/src/commands/command_wrapper.ts
@@ -1,28 +1,30 @@
-import { MissingLibrary } from '@/error';
 import { senUtils } from '@/utils';
 import { showMessage } from '@/utils/vscode';
-import vscode from 'vscode';
+
+type Argument<T = any> = { [key: string]: T } & { length?: never };
 
 export interface Parameter {
-	argument: Array<string>;
+	argument: Argument<any>;
 	success?: () => void;
 	exception?: () => void;
 }
 
+function construct_argument(argument: Argument<any>): Array<string> {
+	const result = [] as Array<string>;
+	for (let [key, value] of Object.entries(argument)) {
+		result.push(key, value);
+	}
+	return result;
+}
+
 export async function spawn_launcher({ argument, success, exception }: Parameter): Promise<void> {
 	try {
-		await senUtils.runSenAndExecute(argument);
+		await senUtils.runSenAndExecute(construct_argument(argument));
 		if (success !== undefined) {
 			success();
 		}
 	} catch (error) {
-		if (
-			error instanceof Error ||
-			error instanceof MissingLibrary ||
-			error instanceof vscode.CancellationError
-		) {
-			showMessage(error.message, 'error');
-		}
+		showMessage((error as Error).message, 'error');
 		if (exception !== undefined) {
 			exception();
 		}

--- a/src/commands/obb/buildProject.ts
+++ b/src/commands/obb/buildProject.ts
@@ -1,5 +1,5 @@
 import { ProjectConfig, textureCategory, ValidationPathType } from '@/types';
-import { fileUtils, senUtils } from '@/utils';
+import { fileUtils } from '@/utils';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
@@ -14,14 +14,12 @@ import { showInfo, showMessage } from '@/utils/vscode';
 
 export function execute(context: vscode.ExtensionContext) {
 	return async (uri: vscode.Uri) => {
-		const allowedExtensions = ['.senproj', '.bundle'];
+		const allowedExtensions = /(\.(senproj|bundle))$/i;
 
 		const projectPath = uri
 			? await fileUtils.validatePath(uri, ValidationPathType.folder, allowedExtensions, {
 					fileNotFound: 'Project not found!',
-					invalidFileType: `Unsupported file type! Supported file type: ${allowedExtensions.join(
-						', ',
-					)}`,
+					invalidFileType: `Unsupported file type! Supported file type: ${allowedExtensions}`,
 			  })
 			: await fileUtils.validateWorkspacePath(allowedExtensions);
 
@@ -64,16 +62,12 @@ export function execute(context: vscode.ExtensionContext) {
 		const destinationPath = obbPath.replace('.bundle', '');
 
 		await spawn_launcher({
-			argument: [
-				'-method',
-				'popcap.rsb.build_project',
-				'-source',
-				obbPath,
-				'-destination',
-				destinationPath,
-				'-generic',
-				textureCategoryOption,
-			],
+			argument: {
+				method: 'popcap.rsb.build_project',
+				source: obbPath,
+				destination: destinationPath,
+				generic: textureCategoryOption,
+			},
 			success() {
 				assert_if(fs.existsSync(destinationPath), 'Failed to convert pam to xfl!');
 				showMessage(`Project built successfully!\nLocated at ${destinationPath}`, 'info');

--- a/src/commands/scg/decodeAdvanced.ts
+++ b/src/commands/scg/decodeAdvanced.ts
@@ -1,5 +1,4 @@
 import { ScgOptions, ValidationPathType } from '@/types';
-import { senUtils } from '@/utils';
 import { validatePath, writeSplitLabelIntoJson } from '@/utils/file';
 import * as vscode from 'vscode';
 import * as path from 'path';
@@ -9,9 +8,9 @@ import { spawn_launcher } from '../command_wrapper';
 import { assert_if } from '@/error';
 import { showMessage } from '@/utils/vscode';
 
-export function execute(context: vscode.ExtensionContext) {
+export function execute() {
 	return async (uri: vscode.Uri) => {
-		const scgPath = await validatePath(uri, ValidationPathType.file, ['.scg'], {
+		const scgPath = await validatePath(uri, ValidationPathType.file, /(\.scg)$/i, {
 			fileNotFound: 'SCG not found!',
 			invalidFileType: 'Unsupported file type! Supported file type: .scg',
 		});
@@ -25,18 +24,13 @@ export function execute(context: vscode.ExtensionContext) {
 		const fileDestination = scgPath.replace('.scg', '.package');
 
 		await spawn_launcher({
-			argument: [
-				'-method',
-				'pvz2.custom.scg.decode',
-				'-source',
-				scgPath,
-				'-destination',
-				fileDestination,
-				'-generic',
-				ScgOptions.Advanced,
-				'-animation_split_label',
-				isSplitLabel,
-			],
+			argument: {
+				method: 'pvz2.custom.scg.decode',
+				source: scgPath,
+				destination: fileDestination,
+				generic: ScgOptions.Advanced,
+				animation_split_label: isSplitLabel,
+			},
 			success() {
 				assert_if(fs.existsSync(fileDestination), 'Failed to decode SCG!');
 				showMessage('SCG decoded successfully!', 'info');

--- a/src/commands/scg/decodeSimple.ts
+++ b/src/commands/scg/decodeSimple.ts
@@ -1,5 +1,4 @@
 import { ScgOptions, ValidationPathType } from '@/types';
-import { senUtils } from '@/utils';
 import { validatePath } from '@/utils/file';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
@@ -7,9 +6,9 @@ import { spawn_launcher } from '../command_wrapper';
 import { assert_if } from '@/error';
 import { showMessage } from '@/utils/vscode';
 
-export function execute(context: vscode.ExtensionContext) {
+export function execute() {
 	return async (uri: vscode.Uri) => {
-		const scgPath = await validatePath(uri, ValidationPathType.file, ['.scg'], {
+		const scgPath = await validatePath(uri, ValidationPathType.file, /(\.scg)$/i, {
 			fileNotFound: 'SCG not found!',
 			invalidFileType: 'Unsupported file type! Supported file type: .scg',
 		});
@@ -21,16 +20,12 @@ export function execute(context: vscode.ExtensionContext) {
 		const fileDestination = scgPath.replace('.scg', '.package');
 
 		await spawn_launcher({
-			argument: [
-				'-method',
-				'pvz2.custom.scg.decode',
-				'-source',
-				scgPath,
-				'-destination',
-				fileDestination,
-				'-generic',
-				ScgOptions.Simple,
-			],
+			argument: {
+				method: 'pvz2.custom.scg.decode',
+				source: scgPath,
+				destination: fileDestination,
+				generic: ScgOptions.Simple,
+			},
 			success() {
 				assert_if(fs.existsSync(fileDestination), 'Failed to decode SCG!');
 				showMessage('SCG decoded successfully!', 'info');

--- a/src/commands/scg/encodeAdvanced.ts
+++ b/src/commands/scg/encodeAdvanced.ts
@@ -1,17 +1,17 @@
 import * as vscode from 'vscode';
 import { ScgOptions, ValidationPathType } from '@/types';
-import { fileUtils, senUtils } from '@/utils';
+import { fileUtils } from '@/utils';
 import * as fs from 'fs';
 import { spawn_launcher } from '../command_wrapper';
 import { assert_if } from '@/error';
 import { showMessage } from '@/utils/vscode';
 
-export function execute(context: vscode.ExtensionContext) {
+export function execute() {
 	return async (uri: vscode.Uri) => {
 		const packagePath = await fileUtils.validatePath(
 			uri,
 			ValidationPathType.folder,
-			['.package'],
+			/(\.package)$/i,
 			{
 				fileNotFound: 'Package not found!',
 				invalidFileType: 'Unsupported file type! Supported file type: .package',
@@ -27,18 +27,13 @@ export function execute(context: vscode.ExtensionContext) {
 		const fileDestination = packagePath.replace('.package', '.scg');
 
 		await spawn_launcher({
-			argument: [
-				'-method',
-				'pvz2.custom.scg.encode',
-				'-source',
-				packagePath,
-				'-destination',
-				fileDestination,
-				'-generic',
-				ScgOptions.Advanced,
-				'-animation_split_label',
-				isSplitLabel,
-			],
+			argument: {
+				method: 'pvz2.custom.scg.encode',
+				source: packagePath,
+				destination: fileDestination,
+				generic: ScgOptions.Advanced,
+				animation_split_label: isSplitLabel,
+			},
 			success() {
 				assert_if(fs.existsSync(fileDestination), 'Failed to decode SCG!');
 				showMessage('SCG encoded successfully!', 'info');

--- a/src/commands/scg/encodeSimple.ts
+++ b/src/commands/scg/encodeSimple.ts
@@ -1,17 +1,17 @@
 import * as vscode from 'vscode';
 import { ScgOptions, ValidationPathType } from '@/types';
-import { fileUtils, senUtils } from '@/utils';
+import { fileUtils } from '@/utils';
 import * as fs from 'fs';
 import { spawn_launcher } from '../command_wrapper';
 import { assert_if } from '@/error';
 import { showMessage } from '@/utils/vscode';
 
-export function execute(context: vscode.ExtensionContext) {
+export function execute() {
 	return async (uri: vscode.Uri) => {
 		const packagePath = await fileUtils.validatePath(
 			uri,
 			ValidationPathType.folder,
-			['.package'],
+			/(\.package)$/i,
 			{
 				fileNotFound: 'Package not found!',
 				invalidFileType: 'Unsupported file type! Supported file type: .package',
@@ -25,16 +25,12 @@ export function execute(context: vscode.ExtensionContext) {
 		const fileDestination = packagePath.replace('.package', '.scg');
 
 		await spawn_launcher({
-			argument: [
-				'-method',
-				'pvz2.custom.scg.encode',
-				'-source',
-				packagePath,
-				'-destination',
-				fileDestination,
-				'-generic',
-				ScgOptions.Simple,
-			],
+			argument: {
+				method: 'pvz2.custom.scg.encode',
+				source: packagePath,
+				destination: fileDestination,
+				generic: ScgOptions.Simple,
+			},
 			success() {
 				assert_if(fs.existsSync(fileDestination), 'Failed to decode SCG!');
 				showMessage('SCG encoded successfully!', 'info');

--- a/src/commands/sen/openGUI.ts
+++ b/src/commands/sen/openGUI.ts
@@ -1,8 +1,7 @@
 import * as SenUtils from '@/utils/sen';
 import { showError } from '@/utils/vscode';
-import * as vscode from 'vscode';
 
-export function execute(context: vscode.ExtensionContext) {
+export function execute() {
 	return async () => {
 		await SenUtils.openSenGui().catch((error) => {
 			showError(error);

--- a/src/utils/file/jsonUtils.ts
+++ b/src/utils/file/jsonUtils.ts
@@ -30,7 +30,7 @@ export function writeSplitLabelIntoJson(pathParam: string, isSplitLabel: boolean
 		'#split_label': isSplitLabel ?? isEncodeWithSplitLabel(pathParam),
 	};
 
-	const dataJsonStr = JSON.stringify({ ...splitLabel, ...data_file }, null, 4);
+	const dataJsonStr = JSON.stringify({ ...splitLabel, ...data_file }, null, '\t');
 
 	try {
 		const dataJsonPath = path.join(pathParam, 'data.json');

--- a/src/utils/file/jsonUtils.ts
+++ b/src/utils/file/jsonUtils.ts
@@ -1,4 +1,4 @@
-import { DataJson, ProjectConfig, textureCategory } from '@/types';
+import { DataJson } from '@/types';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -19,10 +19,10 @@ function readDataJson(
 }
 
 export function writeSplitLabelIntoJson(pathParam: string, isSplitLabel: boolean): void {
-	const dataJson: DataJson | null = readDataJson(pathParam);
+	const data_file: DataJson | null = readDataJson(pathParam);
 
-	if (!dataJson) {
-		showError(`Failed to write ${pathParam}\\data.json: Missing data.json!`);
+	if (data_file === undefined) {
+		showError(`Failed to write ${pathParam}/data.json: Missing data.json!`);
 		return;
 	}
 
@@ -30,20 +30,20 @@ export function writeSplitLabelIntoJson(pathParam: string, isSplitLabel: boolean
 		'#split_label': isSplitLabel ?? isEncodeWithSplitLabel(pathParam),
 	};
 
-	const dataJsonStr = JSON.stringify({ ...splitLabel, ...dataJson }, null, 4);
+	const dataJsonStr = JSON.stringify({ ...splitLabel, ...data_file }, null, 4);
 
 	try {
 		const dataJsonPath = path.join(pathParam, 'data.json');
 		fs.createWriteStream(dataJsonPath, { flags: 'w' }).write(dataJsonStr);
 	} catch (error) {
-		showError(`Failed to write ${pathParam}\\data.json: ${error}`);
+		showError(`Failed to write ${pathParam}/data.json: ${error}`);
 	}
 }
 
 export function isEncodeWithSplitLabel(pathParam: string): boolean {
 	const dataJson: DataJson | null = readDataJson(pathParam);
 
-	if (!dataJson || !dataJson['#split_label']) {
+	if (dataJson === null || !dataJson['#split_label']) {
 		return true;
 	}
 
@@ -52,7 +52,7 @@ export function isEncodeWithSplitLabel(pathParam: string): boolean {
 
 export function writeJson(pathParam: string, data: any) {
 	try {
-		fs.writeFileSync(pathParam, JSON.stringify(data, null, 4));
+		fs.writeFileSync(pathParam, JSON.stringify(data, null, '\t'));
 	} catch (error) {
 		showError(`Failed to write ${pathParam}: ${error}`);
 	}

--- a/src/utils/sen/senLauncher.ts
+++ b/src/utils/sen/senLauncher.ts
@@ -11,7 +11,7 @@ export async function runSenAndExecute(args: string[]): Promise<void> {
 			title: 'Running command...',
 			cancellable: true,
 		},
-		async (progress, token) => {
+		async (_, token) => {
 			return new Promise((resolve, reject) => {
 				const launcherPath = getLauncherPath();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,13 +6,18 @@
 		"paths": {
 			"@/*": ["./src/*"]
 		},
-		"sourceMap": true,
+		"sourceMap": false,
 		"rootDir": "src",
 		"strict": true,
-		"outDir": "./build"
+		"outDir": "./build",
+		"strictNullChecks": true,
+		"alwaysStrict": true,
+		"allowUnreachableCode": false,
+		"preserveConstEnums": false
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
-		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
+		// "noUnusedParameters": true,
+		// "noUnusedLocals": true
 	}
 }


### PR DESCRIPTION
Make the argument look better on key: value style.
example:
```ts
argument: [
        '-method',
        'popcap.animation.from_flash_and_encode',
        '-source',
        xflPath,
        '-destination',
        destinationPath,
        '-has_label',
        isSplitLabel,
],
```
to:
```ts
argument: {
        method: 'popcap.animation.from_flash_and_encode',
        source: xflPath,
        destination: destinationPath,
        has_label: isSplitLabel,
},
```
- Validate path change to regular expression
- Remove unnecessary imports and variables